### PR TITLE
Simplify BEM preset

### DIFF
--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -11,7 +11,7 @@ module.exports = {
     utilitySelectors: /^\.u(?:-[a-z][a-zA-Z0-9]+)+$/
   },
   bem: {
-    componentName: /[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*/,
+    componentName: /[a-z0-9]+(?:-[a-z0-9]+)*/i,
     componentSelectors: bemSelector
   }
 };
@@ -40,11 +40,8 @@ function suitSelector(componentName, opts) {
  * @returns {RegExp}
  */
 function bemSelector(block) {
-  var WORD = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
-  var element = '(?:__' + WORD + ')';
-  var modifier = '(?:(?:_' + WORD + '){1,2})';
-  return new RegExp(
-    '^\\.' + block + modifier + '?$' +
-    '|^\\.' + block + element + modifier + '?$'
-  );
+  var WORD = '[a-z0-9]+(?:-[a-z0-9]+)*';
+  var element = '(?:__' + WORD + ')?';
+  var modifier = '(?:_' + WORD + '){0,2}';
+  return new RegExp('^\\.' + block + element + modifier + '$', 'i');
 }


### PR DESCRIPTION
1. The regular expressions in the BEM preset can be simplified with the case insensitive `i` flag.
1. Making the `element` and `modifier` optional, the `new RegExp` becomes quite simplified.