### PR TITLE
Added support for ignoreSelectors as string

### DIFF
--- a/lib/should-ignore-selector.js
+++ b/lib/should-ignore-selector.js
@@ -1,6 +1,22 @@
 // patterns can be a single regexp or an array of regexps
 module.exports = function(selector, patterns) {
-  return [].concat(patterns).some(function(p) {
+  patterns = [].concat(patterns).map(function(p) {
+    if (typeof p === 'string') {
+      if (!p.length) {
+        throw (new Error('`ignorePattern` is empty'));
+      }
+
+      try {
+        p = new RegExp(p);
+      } catch (err) {
+        throw (new Error(p + ' is not a valid regex'));
+      }
+    }
+
+    return p;
+  });
+
+  return patterns.some(function(p) {
     return p.test(selector);
   });
 }

--- a/test/utility-validation.js
+++ b/test/utility-validation.js
@@ -28,17 +28,55 @@ describe('utility validation', function() {
         utilitySelectors: /\.[A-Z]+/,
         ignoreSelectors: /\.isok-[a-z]+/,
       };
+      var ignoreString = Object.assign({}, configWithIgnore, {
+        ignoreSelectors: '\\.isok-[a-z]+',
+      });
+      var badIgnoreString = Object.assign({}, configWithIgnore, {
+        ignoreSelectors: '(',
+      });
+      var emptyIgnoreString = Object.assign({}, configWithIgnore, {
+        ignoreSelectors: '',
+      });
 
       it('accepts valid selectors', function(done) {
-        util.assertSuccess(done, '/** @define utilities */ .FOO {}', configWithIgnore);
+        var css = '/** @define utilities */ .FOO {}';
+
+        util.assertSuccess(function () {
+          util.assertSuccess(done, css, ignoreString);
+        }, css, configWithIgnore);
       });
 
       it('rejected invalid selectors that do not match ignore pattern', function(done) {
-        util.assertSingleFailure(done, '/** @define utilities */ .foo {}', configWithIgnore);
+        var css = '/** @define utilities */ .foo {}';
+
+        util.assertSingleFailure(function () {
+          util.assertSingleFailure(done, css, ignoreString);
+        }, css, configWithIgnore);
       });
 
       it('ignores selectors that match ignore pattern', function(done) {
-        util.assertSuccess(done, '/** @define utilities */ .isok-bar {}', configWithIgnore);
+        var css = '/** @define utilities */ .isok-bar {}';
+
+        util.assertSuccess(function () {
+          util.assertSuccess(done, css, ignoreString);
+        }, css, configWithIgnore);
+      });
+
+      it('rejects invalid regexp string', function(done) {
+        util.test('/** @define utilities */ .isok-bar {}', badIgnoreString)
+          .catch(function(err) {
+            var expected = badIgnoreString.ignoreSelectors + ' is not a valid regex';
+            assert.equal(err.message, expected);
+            done();
+          });
+      });
+
+      it('rejects empty regexp string', function(done) {
+        util.test('/** @define utilities */ .isok-bar {}', badIgnoreString)
+          .catch(function(err) {
+            assert.notEqual(err.message, '`ignorePattern` is empty');
+            done();
+          });
       });
     });
   });

--- a/test/utility-validation.js
+++ b/test/utility-validation.js
@@ -28,15 +28,18 @@ describe('utility validation', function() {
         utilitySelectors: /\.[A-Z]+/,
         ignoreSelectors: /\.isok-[a-z]+/,
       };
-      var ignoreString = Object.assign({}, configWithIgnore, {
+      var ignoreString = {
+        utilitySelectors: /\.[A-Z]+/,
         ignoreSelectors: '\\.isok-[a-z]+',
-      });
-      var badIgnoreString = Object.assign({}, configWithIgnore, {
+      };
+      var badIgnoreString = {
+        utilitySelectors: /\.[A-Z]+/,
         ignoreSelectors: '(',
-      });
-      var emptyIgnoreString = Object.assign({}, configWithIgnore, {
+      };
+      var emptyIgnoreString = {
+        utilitySelectors: /\.[A-Z]+/,
         ignoreSelectors: '',
-      });
+      };
 
       it('accepts valid selectors', function(done) {
         var css = '/** @define utilities */ .FOO {}';


### PR DESCRIPTION
I'm using this with [postcss-cli](https://github.com/code42day/postcss-cli) but ran into trouble when trying to implement `ignoreSelectors` since the options to postcss-cli are all strings.

Take my simple `npm test` script:

```
postcss -u postcss-bem-linter --postcss-bem-linter.preset suit --postcss-bem-linter.ignoreSelectors '\\.no-.+' -u postcss-reporter --postcss-reporter.throwError -d $TMPDIR ./components/**/*.css
```

So if ignoreSelectors is a string I try and convert it into a RegExp. I also added tests by piggybacking on the existing tests for `ignoreSelectors`.
