### PR TITLE
Support string patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+=== Head
+
+* Support string patterns for everything: `componentName`, `componentSelectors` (with one description, and with `initial` and `combined`), `utilitySelectors`, and `ignoreSelectors` (with a single value or an array).
+
 === 2.0.0 (October 17, 2015)
 
 * Add namespace option to BEM preset pattern.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var validateCustomProperties = require('./lib/validate-custom-properties');
 var validateUtilities = require('./lib/validate-utilities');
 var validateSelectors = require('./lib/validate-selectors');
 var generateConfig = require('./lib/generate-config');
+var toRegexp = require('./lib/to-regexp');
 
 var DEFINE_VALUE = '([-_a-zA-Z0-9]+)\\s*(?:;\\s*(weak))?';
 var DEFINE_DIRECTIVE = new RegExp(
@@ -51,8 +52,8 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
         }
         validateUtilities({
           rule: rule,
-          utilityPattern: config.patterns.utilitySelectors,
-          ignorePattern: config.patterns.ignoreSelectors,
+          utilityPattern: toRegexp(config.patterns.utilitySelectors),
+          ignorePattern: toRegexp(config.patterns.ignoreSelectors),
           result: result,
         });
         return;
@@ -71,7 +72,7 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
         weakMode: range.weakMode,
         selectorPattern: config.patterns.componentSelectors,
         selectorPatternOptions: config.presetOptions,
-        ignorePattern: config.patterns.ignoreSelectors,
+        ignorePattern: toRegexp(config.patterns.ignoreSelectors),
         result: result,
       });
     }
@@ -89,7 +90,7 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
         var directiveMatch = comment.text.match(DEFINE_DIRECTIVE);
         if (!directiveMatch) return;
         var defined = (directiveMatch[1] || directiveMatch[3]).trim();
-        if (defined !== UTILITIES_IDENT && !defined.match(config.componentNamePattern)) {
+        if (defined !== UTILITIES_IDENT && !defined.match(toRegexp(config.componentNamePattern))) {
           result.warn(
             'Invalid component name in definition /*' + comment + '*/',
             { node: comment }

--- a/lib/to-interpolated-regexp.js
+++ b/lib/to-interpolated-regexp.js
@@ -1,0 +1,14 @@
+module.exports = function(source) {
+  if (typeof source === 'string') {
+    var splitSource = source.split('{componentName}');
+    return function(componentName) {
+      try {
+        return new RegExp(splitSource[0] + componentName + splitSource[1]);
+      } catch (e) {
+        throw new Error('"' + source + '" does not produce a valid regular expression');
+      }
+    }
+  } else {
+    return source;
+  }
+}

--- a/lib/to-regexp.js
+++ b/lib/to-regexp.js
@@ -1,0 +1,23 @@
+module.exports = function(source) {
+  if (Array.isArray(source)) {
+    return source.map(regexpify);
+  } else {
+    return regexpify(source);
+  }
+};
+
+function regexpify(source) {
+  if (typeof source === 'string') {
+    if (!source.length) {
+      throw new Error('`ignorePattern` is empty');
+    }
+
+    try {
+      return new RegExp(source);
+    } catch (e) {
+      throw new Error('"' + source + '" is not a valid regular expression');
+    }
+  } else {
+    return source;
+  }
+}

--- a/lib/to-regexp.js
+++ b/lib/to-regexp.js
@@ -9,7 +9,7 @@ module.exports = function(source) {
 function regexpify(source) {
   if (typeof source === 'string') {
     if (!source.length) {
-      throw new Error('`ignorePattern` is empty');
+      throw new Error('You passed an empty pattern');
     }
 
     try {

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -1,6 +1,7 @@
 var listSequences = require('./list-sequences');
 var shouldIgnoreRule = require('./should-ignore-rule');
 var shouldIgnoreSelector = require('./should-ignore-selector');
+var toInterpoloatedRegexp = require('./to-interpolated-regexp');
 
 /**
  * @param {Object} config
@@ -17,11 +18,11 @@ module.exports = function(config) {
   if (shouldIgnoreRule(config.rule)) return;
 
   var initialPattern = (config.selectorPattern.initial)
-    ? config.selectorPattern.initial(config.componentName, config.selectorPatternOptions)
-    : config.selectorPattern(config.componentName, config.selectorPatternOptions);
+    ? toInterpoloatedRegexp(config.selectorPattern.initial)(config.componentName, config.selectorPatternOptions)
+    : toInterpoloatedRegexp(config.selectorPattern)(config.componentName, config.selectorPatternOptions);
   var combinedPattern = (config.selectorPattern.combined)
-    ? config.selectorPattern.combined(config.componentName, config.selectorPatternOptions)
-    : initialPattern;
+    ? toInterpoloatedRegexp(config.selectorPattern.combined)(config.componentName, config.selectorPatternOptions)
+    : toInterpoloatedRegexp(initialPattern);
   var selectors = config.rule.selectors;
 
   selectors.forEach(function(selector) {

--- a/test/ignore-selectors.js
+++ b/test/ignore-selectors.js
@@ -25,69 +25,87 @@ describe('ignoring selectors', function() {
   });
 
   describe('ignore a selector with an `ignoreSelectors` pattern', function() {
-    var s = selectorTester('/** @define Foo */');
-    var config = { preset: 'suit', ignoreSelectors: /\.isok-.+/ };
+    describe('that is a regular expression', function() {
+      runTests(/\.isok-.+/);
+    });
+    describe('that is a string', function() {
+      runTests('.isok-.+');
+    });
 
-    it(
-      'ignores selectors that match the `ignoreSelectors` pattern',
-      function() {
-        assertSuccess(s('.isok-BLERGH'), config);
-      }
-    );
+    function runTests(ignoreSelectors) {
+      var s = selectorTester('/** @define Foo */');
+      var config = { preset: 'suit', ignoreSelectors: ignoreSelectors };
 
-    it(
-      'ignores grouped selectors that match the `ignoreSelectors` pattern',
-      function() {
-        assertSuccess(s('.Foo .isok-BLERGH'), config);
-      }
-    );
+      it(
+        'ignores selectors that match the `ignoreSelectors` pattern',
+        function() {
+          assertSuccess(s('.isok-BLERGH'), config);
+        }
+      );
 
-    it(
-      'rejects selectors that do not match valid pattern or `ignoreSelectors` pattern',
-      function() {
-        assertSingleFailure(s('.blergh'), config);
-      }
-    );
+      it(
+        'ignores grouped selectors that match the `ignoreSelectors` pattern',
+        function() {
+          assertSuccess(s('.Foo .isok-BLERGH'), config);
+        }
+      );
+
+      it(
+        'rejects selectors that do not match valid pattern or `ignoreSelectors` pattern',
+        function() {
+          assertSingleFailure(s('.blergh'), config);
+        }
+      );
+    }
   });
 
   describe('ignore a selector with an `ignoreSelectors` array of patterns', function() {
-    var s = selectorTester('/** @define Foo */');
-    var config = { preset: 'suit', ignoreSelectors: [/\.isok-.+/, /#fine/] };
+    describe('each item of which is a regular expression', function() {
+      runTests([/\.isok-.+/, /#fine/]);
+    });
+    describe('each item of which is a string', function() {
+      runTests(['.isok-.+', '#fine']);
+    });
 
-    it(
-      'ignores selectors that match any of the `ignoreSelectors` pattern',
-      function() {
-        assertSuccess(s('.isok-BLERGH'), config);
-      }
-    );
+    function runTests(ignoreSelectors) {
+      var s = selectorTester('/** @define Foo */');
+      var config = { preset: 'suit', ignoreSelectors: ignoreSelectors };
 
-    it(
-      'ignores selectors that match any of the `ignoreSelectors` pattern (take 2)',
-      function() {
-        assertSuccess(s('#fine'), config);
-      }
-    );
+      it(
+        'ignores selectors that match any of the `ignoreSelectors` pattern',
+        function() {
+          assertSuccess(s('.isok-BLERGH'), config);
+        }
+      );
 
-    it(
-      'ignores grouped selectors that match any of the `ignoreSelectors` pattern',
-      function() {
-        assertSuccess(s('.Foo .isok-BLERGH'), config);
-      }
-    );
+      it(
+        'ignores selectors that match any of the `ignoreSelectors` pattern (take 2)',
+        function() {
+          assertSuccess(s('#fine'), config);
+        }
+      );
 
-    it(
-      'ignores grouped selectors that match any of the `ignoreSelectors` pattern (take 2)',
-      function() {
-        assertSuccess(s('.Foo #fine'), config);
-      }
-    );
+      it(
+        'ignores grouped selectors that match any of the `ignoreSelectors` pattern',
+        function() {
+          assertSuccess(s('.Foo .isok-BLERGH'), config);
+        }
+      );
 
-    it(
-      'rejects selectors that do not match valid pattern or `ignoreSelectors` pattern',
-      function() {
-        assertSingleFailure(s('.blergh'), config);
-      }
-    );
+      it(
+        'ignores grouped selectors that match any of the `ignoreSelectors` pattern (take 2)',
+        function() {
+          assertSuccess(s('.Foo #fine'), config);
+        }
+      );
+
+      it(
+        'rejects selectors that do not match valid pattern or `ignoreSelectors` pattern',
+        function() {
+          assertSingleFailure(s('.blergh'), config);
+        }
+      );
+    }
   });
 
   describe('ignore utility selectors with a comment', function() {
@@ -111,21 +129,30 @@ describe('ignoring selectors', function() {
   });
 
   describe('ignore utility selectors with an `ignoreSelectors` pattern', function() {
-    var configWithIgnore = {
-      utilitySelectors: /\.[A-Z]+/,
-      ignoreSelectors: /\.isok-[a-z]+/,
-    };
-
-    it('accepts valid selectors', function() {
-      util.assertSuccess('/** @define utilities */ .FOO {}', configWithIgnore);
+    describe('that is a regular expression', function() {
+      runTests(/\.isok-[a-z]+$/);
     });
+    describe('that is a string', function() {
+      runTests('.isok-[a-z]+$');
+    })
 
-    it('rejected invalid selectors that do not match ignore pattern', function() {
-      util.assertSingleFailure('/** @define utilities */ .foo {}', configWithIgnore);
-    });
+    function runTests(ignoreSelectors) {
+      var configWithIgnore = {
+        utilitySelectors: /\.[A-Z]+/,
+        ignoreSelectors: ignoreSelectors,
+      };
 
-    it('ignores selectors that match ignore pattern', function() {
-      util.assertSuccess('/** @define utilities */ .isok-bar {}', configWithIgnore);
-    });
+      it('accepts valid selectors', function() {
+        util.assertSuccess('/** @define utilities */ .FOO {}', configWithIgnore);
+      });
+
+      it('rejected invalid selectors that do not match ignore pattern', function() {
+        util.assertSingleFailure('/** @define utilities */ .foo {}', configWithIgnore);
+      });
+
+      it('ignores selectors that match ignore pattern', function() {
+        util.assertSuccess('/** @define utilities */ .isok-bar {}', configWithIgnore);
+      });
+    }
   });
 });

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -15,122 +15,147 @@ describe('selector validation', function() {
   });
 
   describe('with a custom `componentName` pattern /^[A-Z]+$/', function() {
-    var p1 = {
-      componentName: /^[A-Z]+$/,
-      componentSelectors: function() { return /.*/; },
-    };
-
-    it('rejects component name Foo', function() {
-      assertSingleFailure('/** @define Foo */', p1);
+    describe('as a regular expression', function() {
+      runTests(/^[A-Z]+$/);
+    });
+    describe('as a string', function() {
+      runTests('^[A-Z]+$');
     });
 
-    it('accepts component name FOO', function() {
-      assertSuccess('/** @define FOO */', p1);
-    });
+    function runTests(componentName) {
+      var p1 = {
+        componentName: componentName,
+        componentSelectors: function() { return /.*/; },
+      };
+
+      it('rejects component name Foo', function() {
+        assertSingleFailure('/** @define Foo */', p1);
+      });
+
+      it('accepts component name FOO', function() {
+        assertSuccess('/** @define FOO */', p1);
+      });
+    }
   });
 
   describe('with a custom `componentName` pattern /^[a-z]+1$/', function() {
-    var p2 = {
-      componentName: /^[a-z]+1$/,
-      componentSelectors: function() { return /.*/; },
-    };
-
-    it('rejects component name foo2', function() {
-      assertSingleFailure('/** @define foo2 */', p2);
+    describe('as a regular expression', function() {
+      runTests(/^[a-z]+1$/);
+    });
+    describe('as a string', function() {
+      runTests('^[a-z]+1$');
     });
 
-    it('accepts component name abc1', function() {
-      assertSuccess('/** @define abc1 */', p2);
-    });
+    function runTests(componentName) {
+      var p2 = {
+        componentName: componentName,
+        componentSelectors: function() { return /.*/; },
+      };
+
+      it('rejects component name foo2', function() {
+        assertSingleFailure('/** @define foo2 */', p2);
+      });
+
+      it('accepts component name abc1', function() {
+        assertSuccess('/** @define abc1 */', p2);
+      });
+    }
   });
 
   describe(
     'with a single `componentSelectors` pattern ' +
     'RegExp("^\\.[a-z]+-" + cmpt + "(?:_[a-z]+)?$")',
     function() {
-      var patternA = {
-        componentSelectors: function(cmpt) {
+      describe('as a regular expression', function() {
+        runTests(function(cmpt) {
           return new RegExp('^\\.[a-z]+-' + cmpt + '(?:_[a-z]+)?$');
-        },
-      };
-      var s = selectorTester('/** @define Foo */');
-
-      it('accepts valid initial componentSelectors', function() {
-        var valid = util.fixture('patternA-valid');
-        assertSuccess(valid, patternA);
+        });
+      });
+      describe('as a string', function() {
+        runTests('^\\.[a-z]+-{componentName}(?:_[a-z]+)?$');
       });
 
-      it('rejects initial componentSelector `.Foo`', function() {
-        assertSingleFailure(s('.Foo'), patternA);
-      });
+      function runTests(componentSelectors) {
+        var patternA = { componentSelectors: componentSelectors };
+        var s = selectorTester('/** @define Foo */');
 
-      it(
-        'rejects initial componentSelectors in media queries',
-        function() {
-          assertSingleFailure(
-                        '/** @define Foo */ @media all { .Bar {} }'
-          );
-        }
-      );
-
-      describe('with pseudo-selectors', function() {
-        it('ignores `:hover` at the end of a sequence', function() {
-          assertSuccess(s('.f-Foo:hover'), patternA);
+        it('accepts valid initial componentSelectors', function() {
+          var valid = util.fixture('patternA-valid');
+          assertSuccess(valid, patternA);
         });
 
-        it('ignores `::before` at the end of a sequence', function() {
-          assertSuccess(s('.f-Foo::before'), patternA);
+        it('rejects initial componentSelector `.Foo`', function() {
+          assertSingleFailure(s('.Foo'), patternA);
         });
 
         it(
-          'ignores `:not(".is-open")` at the end of a sequence',
+          'rejects initial componentSelectors in media queries',
           function() {
-            assertSuccess(s('.f-Foo:not(\'.is-open\')'), patternA);
+            assertSingleFailure(
+                          '/** @define Foo */ @media all { .Bar {} }'
+            );
           }
         );
-      });
 
-      describe('with combining', function() {
-        it('accepts `.f-Foo .f-Foo`', function() {
-          assertSuccess(s('.f-Foo .f-Foo'), patternA);
+        describe('with pseudo-selectors', function() {
+          it('ignores `:hover` at the end of a sequence', function() {
+            assertSuccess(s('.f-Foo:hover'), patternA);
+          });
+
+          it('ignores `::before` at the end of a sequence', function() {
+            assertSuccess(s('.f-Foo::before'), patternA);
+          });
+
+          it(
+            'ignores `:not(".is-open")` at the end of a sequence',
+            function() {
+              assertSuccess(s('.f-Foo:not(\'.is-open\')'), patternA);
+            }
+          );
         });
 
-        it('accepts `.f-Foo > .f-Foo`', function() {
-          assertSuccess(s('.f-Foo > .f-Foo'), patternA);
+        describe('with combining', function() {
+          it('accepts `.f-Foo .f-Foo`', function() {
+            assertSuccess(s('.f-Foo .f-Foo'), patternA);
+          });
+
+          it('accepts `.f-Foo > .f-Foo`', function() {
+            assertSuccess(s('.f-Foo > .f-Foo'), patternA);
+          });
+
+          it('rejects `.f-Foo > div`', function() {
+            assertSingleFailure(s('.f-Foo > div'), patternA);
+          });
+
+          it('rejects `.f-Foo + #baz`', function() {
+            assertSingleFailure(s('.f-Foo + #baz'), patternA);
+          });
+
+          it('rejects `.f-Foo~li>a.link#baz.foo`', function() {
+            assertSingleFailure(s('.f-Foo~li>a.link#baz.foo'), patternA);
+          });
         });
 
-        it('rejects `.f-Foo > div`', function() {
-          assertSingleFailure(s('.f-Foo > div'), patternA);
-        });
+        describe('in weak mode', function() {
+          var sWeak = selectorTester('/** @define Foo; weak */');
 
-        it('rejects `.f-Foo + #baz`', function() {
-          assertSingleFailure(s('.f-Foo + #baz'), patternA);
-        });
+          it('accepts `.f-Foo .f-Foo`', function() {
+            assertSuccess(sWeak('.f-Foo .f-Foo'), patternA);
+          });
 
-        it('rejects `.f-Foo~li>a.link#baz.foo`', function() {
-          assertSingleFailure(s('.f-Foo~li>a.link#baz.foo'), patternA);
-        });
-      });
+          it('accepts `.f-Foo > div`', function() {
+            assertSuccess(sWeak('.f-Foo > div'), patternA);
+          });
 
-      describe('in weak mode', function() {
-        var sWeak = selectorTester('/** @define Foo; weak */');
+          it('accepts `.f-Foo + #baz`', function() {
+            assertSuccess(sWeak('.f-Foo + #baz'), patternA);
+          });
 
-        it('accepts `.f-Foo .f-Foo`', function() {
-          assertSuccess(sWeak('.f-Foo .f-Foo'), patternA);
+          it('accepts `.f-Foo~li>a.link#baz.foo`', function() {
+            assertSuccess(sWeak('.f-Foo~li>a.link#baz.foo'), patternA);
+          });
         });
-
-        it('accepts `.f-Foo > div`', function() {
-          assertSuccess(sWeak('.f-Foo > div'), patternA);
-        });
-
-        it('accepts `.f-Foo + #baz`', function() {
-          assertSuccess(sWeak('.f-Foo + #baz'), patternA);
-        });
-
-        it('accepts `.f-Foo~li>a.link#baz.foo`', function() {
-          assertSuccess(sWeak('.f-Foo~li>a.link#baz.foo'), patternA);
-        });
-      });
+      }
     }
   );
 
@@ -138,64 +163,75 @@ describe('selector validation', function() {
     'with different `initial` ("^\\." + cmpt + "(?:-[a-z]+)?$") and ' +
     '`combined` ("^\\.c-" + cmpt + "(?:-[a-z]+)?$") selector patterns',
     function() {
-    var patternB = {
-      componentSelectors: {
-        initial: function(cmpt) {
-          return new RegExp('^\\.' + cmpt + '(?:-[a-z]+)?$');
-        },
-        combined: function(cmpt) {
-          return new RegExp('^\\.c-' + cmpt + '(?:-[a-z]+)?$');
-        },
-      },
-    };
-    var s = selectorTester('/** @define Foo */');
-
-    it('accepts `.Foo .c-Foo`', function() {
-      assertSuccess(s('.Foo .c-Foo'), patternB);
-    });
-
-    it('accepts `.Foo-bar > .c-Foo-bar`', function() {
-      assertSuccess(s('.Foo-bar > .c-Foo-bar'), patternB);
-    });
-
-    it('accepts `.Foo-bar>.c-Foo-bar`', function() {
-      assertSuccess(s('.Foo-bar>.c-Foo-bar'), patternB);
-    });
-
-    it('rejects `.Foo .cc-Foo`', function() {
-      assertSingleFailure(s('.Foo .cc-Foo'), patternB);
-    });
-
-    it('rejects `.Foo > .Foo-F`', function() {
-      assertSingleFailure(s('.Foo > .Foo-F'), patternB);
-    });
-
-    it('rejects `.Foo, .cc-Foo`', function() {
-      assertSingleFailure(s('.Foo, .cc-Foo'), patternB);
-    });
-
-    describe('in weak mode', function() {
-      var sWeak = selectorTester('/** @define Foo; weak*/');
-
-      it('accepts `.Foo .c-Foo`', function() {
-        assertSuccess(sWeak('.Foo .c-Foo'), patternB);
+      describe('as regular expressions', function() {
+        runTests({
+          initial: function(cmpt) {
+            return new RegExp('^\\.' + cmpt + '(?:-[a-z]+)?$');
+          },
+          combined: function(cmpt) {
+            return new RegExp('^\\.c-' + cmpt + '(?:-[a-z]+)?$');
+          },
+        });
+      });
+      describe('as strings', function() {
+        runTests({
+          initial: '^\\.{componentName}(?:-[a-z]+)?$',
+          combined: '^\\.c-{componentName}(?:-[a-z]+)?$',
+        });
       });
 
-      it('accepts `.Foo .Foo`', function() {
-        assertSuccess(sWeak('.Foo .Foo'), patternB);
-      });
+      function runTests(componentSelectors) {
+        var patternB = { componentSelectors: componentSelectors };
+        var s = selectorTester('/** @define Foo */');
 
-      it('accepts `.Foo > div`', function() {
-        assertSuccess(sWeak('.Foo > div'), patternB);
-      });
+        it('accepts `.Foo .c-Foo`', function() {
+          assertSuccess(s('.Foo .c-Foo'), patternB);
+        });
 
-      it('accepts `.Foo + #baz`', function() {
-        assertSuccess(sWeak('.Foo + #baz'), patternB);
-      });
+        it('accepts `.Foo-bar > .c-Foo-bar`', function() {
+          assertSuccess(s('.Foo-bar > .c-Foo-bar'), patternB);
+        });
 
-      it('accepts `.Foo~li>a.link#baz.foo`', function() {
-        assertSuccess(sWeak('.Foo~li>a.link#baz.foo'), patternB);
-      });
-    });
-  });
+        it('accepts `.Foo-bar>.c-Foo-bar`', function() {
+          assertSuccess(s('.Foo-bar>.c-Foo-bar'), patternB);
+        });
+
+        it('rejects `.Foo .cc-Foo`', function() {
+          assertSingleFailure(s('.Foo .cc-Foo'), patternB);
+        });
+
+        it('rejects `.Foo > .Foo-F`', function() {
+          assertSingleFailure(s('.Foo > .Foo-F'), patternB);
+        });
+
+        it('rejects `.Foo, .cc-Foo`', function() {
+          assertSingleFailure(s('.Foo, .cc-Foo'), patternB);
+        });
+
+        describe('in weak mode', function() {
+          var sWeak = selectorTester('/** @define Foo; weak*/');
+
+          it('accepts `.Foo .c-Foo`', function() {
+            assertSuccess(sWeak('.Foo .c-Foo'), patternB);
+          });
+
+          it('accepts `.Foo .Foo`', function() {
+            assertSuccess(sWeak('.Foo .Foo'), patternB);
+          });
+
+          it('accepts `.Foo > div`', function() {
+            assertSuccess(sWeak('.Foo > div'), patternB);
+          });
+
+          it('accepts `.Foo + #baz`', function() {
+            assertSuccess(sWeak('.Foo + #baz'), patternB);
+          });
+
+          it('accepts `.Foo~li>a.link#baz.foo`', function() {
+            assertSuccess(sWeak('.Foo~li>a.link#baz.foo'), patternB);
+          });
+        });
+      }
+    }
+  );
 });

--- a/test/utility-validation.js
+++ b/test/utility-validation.js
@@ -12,14 +12,23 @@ describe('utility validation', function() {
   });
 
   describe('with a `utilitySelectors` pattern', function() {
-    var config = { utilitySelectors: /\.[a-z]+/ };
-
-    it('accepts valid selectors', function() {
-      util.assertSuccess('/** @define utilities */ .foo {}', config);
+    describe('as a regular expression', function() {
+      runTests(/\.[a-z]+/);
+    });
+    describe('as a string', function() {
+      runTests('.[a-z]+');
     });
 
-    it('rejects valid selectors', function() {
-      util.assertSingleFailure('/** @define utilities */ .FOO {}', config);
-    });
+    function runTests(utilitySelectors) {
+      var config = { utilitySelectors: utilitySelectors };
+
+      it('accepts valid selectors', function() {
+        util.assertSuccess('/** @define utilities */ .foo {}', config);
+      });
+
+      it('rejects valid selectors', function() {
+        util.assertSingleFailure('/** @define utilities */ .FOO {}', config);
+      });
+    }
   });
 });


### PR DESCRIPTION
Incorporates and adds to #69. Hopefully makes this plugin completely compatible with postcss-cli.

Also provides important groundwork for https://github.com/postcss/postcss-bem-linter/issues/68.

Alters all applicable tests to try both regular expression and string patterns --- also, interpolated string patterns in addition to functions (for `componentSelectors`).

Also adds documentation.

I am submitting this as a PR before merging in case any watchers have input or feedback.