### PR TITLE
Allow chaining modifier and state in suit selector

### DIFF
--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -20,9 +20,9 @@ function suitSelector(componentName, presetOptions) {
   var ns = (presetOptions && presetOptions.namespace) ? presetOptions.namespace + '-' : '';
   var WORD = '[a-z0-9][a-zA-Z0-9]*';
   var descendant = '(?:-' + WORD + ')?';
-  var modifier = '(?:--' + WORD + ')?';
+  var modifier = '(?:--' + WORD + '(?:\\.' + ns + componentName + descendant + '--' + WORD + ')*)?';
   var attribute = '(?:\\[.+\\])?';
-  var state = '(?:\\.is-' + WORD + ')?';
+  var state = '(?:\\.is-' + WORD + ')*';
   var body = descendant +
     modifier +
     attribute +

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -103,7 +103,7 @@ describe('using SUIT pattern (default)', function() {
     assertSuccess(s('.Foo-input[disabled] ~ .Foo-label'));
     assertSuccess(s('.Foo-inner--password .Foo-input[type="password"]'));
   });
-  
+
   describe('strict SUIT syntax', function() {
     var sComponent = util.selectorTester('/** @define Component */');
 

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -82,6 +82,20 @@ describe('using SUIT pattern (default)', function() {
       assertSuccess(sUtil('.u-16by9'));
     });
   });
+  
+  
+  it('accepts chained modifier selectors', function() {
+    assertSuccess(s('.Foo--big.Foo--colored'));
+    assertSuccess(s('.Foo--big.Foo--colored .Foo-input'));
+    assertSuccess(s('.Foo-input--big.Foo-input--colored'));
+
+  });
+
+  it('accepts chained state selectors', function() {
+    assertSuccess(s('.Foo.is-open.is-disabled .Foo-input'));
+    assertSuccess(s('.Foo--big.is-open.is-disabled .Foo-input.is-invalid'));    
+    assertSuccess(s('.Foo.is-open.is-disabled .Foo-input.is-invalid'));
+  });
 
   it('accepts chained attribute selectors', function() {
     assertSuccess(s('.Foo-input[type=number]'));
@@ -89,7 +103,7 @@ describe('using SUIT pattern (default)', function() {
     assertSuccess(s('.Foo-input[disabled] ~ .Foo-label'));
     assertSuccess(s('.Foo-inner--password .Foo-input[type="password"]'));
   });
-
+  
   describe('strict SUIT syntax', function() {
     var sComponent = util.selectorTester('/** @define Component */');
 


### PR DESCRIPTION
Chaining modifiers and state, like: `.Foo--big.Foo--colored` or `.Foo.is-open.is-disabled`, isn't a problem according to Suit as far as I can read out. I'm already using it in a project. Though I need the `stylelint-disable` comment to pass stylelint. I suggest this plugin to allow chaining, with these changes.