### PR TITLE
Validate nested rulesets

### DIFF
--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -38,9 +38,9 @@ function unWrapSelectors(parent, rule) {
 }
 
 function getSelectors(rule) {
-  // Skip validation on parent rules with no declarations
+  // Skip validation on rules with no declarations
   // as these don't exist after rules have been unwrapped
-  if (isTopLevel(rule.parent) && hasNoDeclarations(rule)) {
+  if (hasNoDeclarations(rule)) {
     return null;
   }
 

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -2,6 +2,40 @@ var listSequences = require('./list-sequences');
 var shouldIgnoreRule = require('./should-ignore-rule');
 var shouldIgnoreSelector = require('./should-ignore-selector');
 var toInterpoloatedRegexp = require('./to-interpolated-regexp');
+var resolveNestedSelector = require('postcss-resolve-nested-selector');
+
+function isTopLevel(node) {
+  return node.type === 'atrule' || node.type === 'root';
+}
+
+function isNestedRule(node) {
+  return node.parent.type === 'rule';
+}
+
+function onlyHasChildRules(node) {
+  return node.nodes.length && node.every(function(child) {
+    return child.type === 'rule';
+  });
+}
+
+function getComponentRootRule(node) {
+  while (!isTopLevel(node.parent)) {
+    node = node.parent;
+  }
+  return node;
+}
+
+function unWrapSelectors(parent, rule) {
+  var selectors = [];
+  parent.walkRules(function(node) {
+    // Only unwrap as far as the current rule being linted
+    if (node.selector !== rule.selector) {return;}
+    node.selectors.forEach(function(selector) {
+      selectors = selectors.concat(resolveNestedSelector(selector, node));
+    });
+  });
+  return selectors;
+}
 
 /**
  * @param {Object} config
@@ -24,6 +58,18 @@ module.exports = function(config) {
     ? toInterpoloatedRegexp(config.selectorPattern.combined)(config.componentName, config.selectorPatternOptions)
     : toInterpoloatedRegexp(initialPattern);
   var selectors = rule.selectors;
+
+  if (isNestedRule(rule)) {
+    var componentRootRule = getComponentRootRule(rule);
+    var nestedSelectors = unWrapSelectors(componentRootRule, rule);
+    selectors = nestedSelectors;
+  }
+
+  // Skip validation on parent rules with no declarations
+  // as these don't exist after rules have been unwrapped
+  if (isTopLevel(rule.parent) && onlyHasChildRules(rule)) {
+    return;
+  }
 
   selectors.forEach(function(selector) {
     // Don't bother with :root

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -9,7 +9,7 @@ function isTopLevel(node) {
 }
 
 function isNestedRule(node) {
-  return node.parent.type === 'rule';
+  return /(?:at)?rule/.test(node.parent.type)
 }
 
 function hasNoDeclarations(node) {

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -12,9 +12,9 @@ function isNestedRule(node) {
   return node.parent.type === 'rule';
 }
 
-function onlyHasChildRules(node) {
+function hasNoDeclarations(node) {
   return node.nodes.length && node.every(function(child) {
-    return child.type === 'rule';
+    return child.type !== 'decl';
   });
 }
 
@@ -40,7 +40,7 @@ function unWrapSelectors(parent, rule) {
 function getSelectors(rule) {
   // Skip validation on parent rules with no declarations
   // as these don't exist after rules have been unwrapped
-  if (isTopLevel(rule.parent) && onlyHasChildRules(rule)) {
+  if (isTopLevel(rule.parent) && hasNoDeclarations(rule)) {
     return null;
   }
 

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -37,6 +37,22 @@ function unWrapSelectors(parent, rule) {
   return selectors;
 }
 
+function getSelectors(rule) {
+  // Skip validation on parent rules with no declarations
+  // as these don't exist after rules have been unwrapped
+  if (isTopLevel(rule.parent) && onlyHasChildRules(rule)) {
+    return null;
+  }
+
+  if (isNestedRule(rule)) {
+    var componentRootRule = getComponentRootRule(rule);
+    var nestedSelectors = unWrapSelectors(componentRootRule, rule);
+    return nestedSelectors;
+  }
+
+  return rule.selectors;
+}
+
 /**
  * @param {Object} config
  * @param {Rule} config.rule - PostCSS Rule
@@ -57,19 +73,9 @@ module.exports = function(config) {
   var combinedPattern = (config.selectorPattern.combined)
     ? toInterpoloatedRegexp(config.selectorPattern.combined)(config.componentName, config.selectorPatternOptions)
     : toInterpoloatedRegexp(initialPattern);
-  var selectors = rule.selectors;
+  var selectors = getSelectors(rule);
 
-  if (isNestedRule(rule)) {
-    var componentRootRule = getComponentRootRule(rule);
-    var nestedSelectors = unWrapSelectors(componentRootRule, rule);
-    selectors = nestedSelectors;
-  }
-
-  // Skip validation on parent rules with no declarations
-  // as these don't exist after rules have been unwrapped
-  if (isTopLevel(rule.parent) && onlyHasChildRules(rule)) {
-    return;
-  }
+  if (!selectors) {return;}
 
   selectors.forEach(function(selector) {
     // Don't bother with :root

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -15,6 +15,7 @@ var toInterpoloatedRegexp = require('./to-interpolated-regexp');
  */
 module.exports = function(config) {
   if (shouldIgnoreRule(config.rule)) return;
+  var rule = config.rule;
 
   var initialPattern = (config.selectorPattern.initial)
     ? toInterpoloatedRegexp(config.selectorPattern.initial)(config.componentName, config.selectorPatternOptions)
@@ -22,7 +23,7 @@ module.exports = function(config) {
   var combinedPattern = (config.selectorPattern.combined)
     ? toInterpoloatedRegexp(config.selectorPattern.combined)(config.componentName, config.selectorPatternOptions)
     : toInterpoloatedRegexp(initialPattern);
-  var selectors = config.rule.selectors;
+  var selectors = rule.selectors;
 
   selectors.forEach(function(selector) {
     // Don't bother with :root
@@ -40,7 +41,7 @@ module.exports = function(config) {
       config.result.warn(
         'Invalid component selector "' + selector + '"',
         {
-          node: config.rule,
+          node: rule,
           word: selector,
         }
       );

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -41,7 +41,7 @@ function getSelectors(rule) {
   // Skip validation on rules with no declarations
   // as these don't exist after rules have been unwrapped
   if (hasNoDeclarations(rule)) {
-    return null;
+    return [];
   }
 
   if (isNestedRule(rule)) {
@@ -74,8 +74,6 @@ module.exports = function(config) {
     ? toInterpoloatedRegexp(config.selectorPattern.combined)(config.componentName, config.selectorPatternOptions)
     : toInterpoloatedRegexp(initialPattern);
   var selectors = getSelectors(rule);
-
-  if (!selectors) {return;}
 
   selectors.forEach(function(selector) {
     // Don't bother with :root

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -5,7 +5,7 @@ var toInterpoloatedRegexp = require('./to-interpolated-regexp');
 var resolveNestedSelector = require('postcss-resolve-nested-selector');
 
 function isTopLevel(node) {
-  return node.type === 'atrule' || node.type === 'root';
+  return node.type === 'root';
 }
 
 function isNestedRule(node) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lib"
   ],
   "dependencies": {
-    "postcss": "^5.0.0"
+    "postcss": "^5.0.0",
+    "postcss-resolve-nested-selector": "^0.1.1"
   },
   "devDependencies": {
     "eslint": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "devDependencies": {
     "eslint": "1.7.3",
-    "mocha": "2.3.3"
+    "mocha": "2.3.3",
+    "rewire": "^2.5.1"
   },
   "scripts": {
     "lint": "eslint .",

--- a/test/bem-pattern.js
+++ b/test/bem-pattern.js
@@ -16,7 +16,7 @@ describe('using BEM pattern', function() {
   describe('when given invalid selectors', function() {
     var s = util.selectorTester('/** @define block */');
 
-    // mirroring tests from http://goo.gl/Db6QPu
+    // mirroring tests from https://goo.gl/G0VZHZ
     it('should not validate elem without block', function() {
       assertSingleFailure(s('__elem'), 'bem');
     });

--- a/test/bem-pattern.js
+++ b/test/bem-pattern.js
@@ -7,6 +7,12 @@ describe('using BEM pattern', function() {
     assertSuccess(util.fixture('bem-valid'), 'bem');
   });
 
+  describe('nesting selectors', function() {
+    it('accepts nested rulesets', function() {
+      assertSuccess(util.fixture('bem-nesting'), 'bem');
+    });
+  });
+
   describe('when given invalid selectors', function() {
     var s = util.selectorTester('/** @define block */');
 

--- a/test/fixtures/bem-nesting.css
+++ b/test/fixtures/bem-nesting.css
@@ -1,0 +1,20 @@
+/** @define block-name */
+
+.block-name {
+  color: green;
+
+  .block-name__element {}
+  &__element {}
+  &__element-modifier {}
+  &_modifier {}
+  &:pseudo-class {}
+  &:pseudo-element {}
+  &::pseudo-element {}
+  &[attr] {}
+}
+
+/** @define block-name; weak **/
+
+.block-name {
+  .other {}
+}

--- a/test/fixtures/suit-nesting.css
+++ b/test/fixtures/suit-nesting.css
@@ -1,0 +1,33 @@
+/** @define Component **/
+
+.Component {
+  color: green;
+
+  .Component-descendant {
+    &:active {}
+    &.is-active {}
+  }
+
+  &.is-stateName {}
+  &-descendant {}
+  &-descendant--modifier {}
+  &--modifier {}
+  &:pseudo-class {}
+  &:pseudo-element {}
+  &::pseudo-element {}
+  &[attr] {}
+}
+
+.Component-standAloneDescendant {}
+
+@media (min-width: 780px) {
+  .Component {
+    .Component-descendant {}
+  }
+}
+
+/** @define ComponentWeak; weak **/
+
+.ComponentWeak {
+  .Other {}
+}

--- a/test/fixtures/suit-nesting.css
+++ b/test/fixtures/suit-nesting.css
@@ -26,6 +26,26 @@
   }
 }
 
+.Component {
+  @nest & .Component-nested {
+    width: 500px;
+  }
+
+  @nest &.is-dark {
+    color: white;
+  }
+}
+
+.Component {
+  & .Component-nested {
+    width: 500px;
+  }
+
+  &.is-dark {
+    color: white;
+  }
+}
+
 /** @define ComponentWeak; weak **/
 
 .ComponentWeak {

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ require('./ignore-selectors');
 require('./property-validation');
 require('./ranges');
 require('./selector-validation');
+require('./nesting');
 require('./suit-pattern');
 require('./utility-validation');
 require('./edge-cases');

--- a/test/nesting.js
+++ b/test/nesting.js
@@ -22,7 +22,7 @@ describe('getSelectors function', function() {
       componentRoot.append({selector: '.Component-d'});
       componentRoot.append({text: 'comment'});
 
-      assert.deepEqual(getSelectors(componentRoot), null);
+      assert.deepEqual(getSelectors(componentRoot), []);
     });
 
     it('should return a selector if the ruleset has declarations', function() {
@@ -56,8 +56,8 @@ describe('getSelectors function', function() {
       descendant.append([hover, state]);
       componentRoot.append(descendant);
 
-      assert.deepEqual(getSelectors(componentRoot), null);
-      assert.deepEqual(getSelectors(descendant), null);
+      assert.deepEqual(getSelectors(componentRoot), []);
+      assert.deepEqual(getSelectors(descendant), []);
       assert.deepEqual(getSelectors(hover), ['.Component .Component-d:hover']);
       assert.deepEqual(getSelectors(state), ['.Component .Component-d.is-active']);
     });
@@ -70,7 +70,7 @@ describe('getSelectors function', function() {
         componentRoot.append([hover, state]);
         root.append(componentRoot);
 
-        assert.deepEqual(getSelectors(componentRoot), null);
+        assert.deepEqual(getSelectors(componentRoot), []);
         assert.deepEqual(getSelectors(hover), ['.Component:hover', '.Component-d:hover']);
         assert.deepEqual(getSelectors(state), ['.Component.is-active', '.Component-d.is-active']);
       });
@@ -97,7 +97,7 @@ describe('getSelectors function', function() {
       componentRoot.append(rule);
       media.append(componentRoot);
 
-      assert.deepEqual(getSelectors(componentRoot), null);
+      assert.deepEqual(getSelectors(componentRoot), []);
       assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
     });
   });
@@ -110,7 +110,7 @@ describe('getSelectors function', function() {
       componentRoot.append(media);
 
       assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
-      assert.deepEqual(getSelectors(componentRoot), null);
+      assert.deepEqual(getSelectors(componentRoot), []);
     });
 
     it('should return a selector for a ruleset with declarations and nested media query', function() {

--- a/test/nesting.js
+++ b/test/nesting.js
@@ -61,6 +61,33 @@ describe('getSelectors function', function() {
       assert.deepEqual(getSelectors(hover), ['.Component .Component-d:hover']);
       assert.deepEqual(getSelectors(state), ['.Component .Component-d.is-active']);
     });
+
+    describe('grouped selectors', function() {
+      it('should unwrap grouped selectors without declarations', function() {
+        var componentRoot = postcss.rule({selector: '.Component, .Component-d'});
+        var hover = postcss.rule({selector: '&:hover'});
+        var state = postcss.rule({selector: '&.is-active'});
+        componentRoot.append([hover, state]);
+        root.append(componentRoot);
+
+        assert.deepEqual(getSelectors(componentRoot), null);
+        assert.deepEqual(getSelectors(hover), ['.Component:hover', '.Component-d:hover']);
+        assert.deepEqual(getSelectors(state), ['.Component.is-active', '.Component-d.is-active']);
+      });
+
+      it('should unwrap grouped selectors with declarations', function() {
+        var componentRoot = postcss.rule({selector: '.Component, .Component-d'});
+        var hover = postcss.rule({selector: '&:hover'});
+        var state = postcss.rule({selector: '&.is-active'});
+        componentRoot.append({prop: 'color', value: 'green'});
+        componentRoot.append([hover, state]);
+        root.append(componentRoot);
+
+        assert.deepEqual(getSelectors(componentRoot), ['.Component', '.Component-d']);
+        assert.deepEqual(getSelectors(hover), ['.Component:hover', '.Component-d:hover']);
+        assert.deepEqual(getSelectors(state), ['.Component.is-active', '.Component-d.is-active']);
+      });
+    });
   });
 
   describe('ruleset within an atrule block', function() {

--- a/test/nesting.js
+++ b/test/nesting.js
@@ -1,0 +1,100 @@
+var assert = require('assert');
+var rewire = require('rewire');
+var postcss = require('postcss');
+var validateSelectors = rewire('../lib/validate-selectors');
+
+describe('getSelectors function', function() {
+  var getSelectors = validateSelectors.__get__('getSelectors');
+  var root, componentRoot;
+
+  beforeEach(function() {
+    root = postcss.root();
+    componentRoot = postcss.rule({selector: '.Component'});
+    root.append(componentRoot);
+  });
+
+  it('should return the selector', function() {
+    assert.deepEqual(getSelectors(componentRoot), ['.Component']);
+  });
+
+  describe('ruleset declarations with nested rulesets', function() {
+    it('should ignore a ruleset that has no declarations', function() {
+      componentRoot.append({selector: '.Component-d'});
+      componentRoot.append({text: 'comment'});
+
+      assert.deepEqual(getSelectors(componentRoot), null);
+    });
+
+    it('should return a selector if the ruleset has declarations', function() {
+      componentRoot.append({prop: 'color', value: 'green'});
+      componentRoot.append({selector: '.Component-d'});
+      componentRoot.append({text: 'comment'});
+
+      assert.deepEqual(getSelectors(componentRoot), ['.Component']);
+    });
+  });
+
+  describe('nested rulesets', function() {
+    it('should unwrap selectors down from the parent to the current rule', function() {
+      var rule = postcss.rule({selector: '.Component-d'});
+      componentRoot.append(rule);
+
+      assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
+    });
+
+    it('should unwrap `&` selectors', function() {
+      var rule = postcss.rule({selector: '&.is-active'});
+      componentRoot.append(rule);
+
+      assert.deepEqual(getSelectors(rule), ['.Component.is-active']);
+    });
+
+    it('should unwrap multiple levels of nested rulesets and skip rules with no declarations', function() {
+      var descendant = postcss.rule({selector: '.Component-d'});
+      var hover = postcss.rule({selector: '&:hover'});
+      var state = postcss.rule({selector: '&.is-active'});
+      descendant.append([hover, state]);
+      componentRoot.append(descendant);
+
+      assert.deepEqual(getSelectors(componentRoot), null);
+      assert.deepEqual(getSelectors(descendant), null);
+      assert.deepEqual(getSelectors(hover), ['.Component .Component-d:hover']);
+      assert.deepEqual(getSelectors(state), ['.Component .Component-d.is-active']);
+    });
+  });
+
+  describe('ruleset within an atrule block', function() {
+    it('should unwrap selectors as normal', function() {
+      var rule = postcss.rule({selector: '.Component-d'});
+      var media = postcss.atRule({name: 'media'});
+      componentRoot.append(rule);
+      media.append(componentRoot);
+
+      assert.deepEqual(getSelectors(componentRoot), null);
+      assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
+    });
+  });
+
+  describe('media queries nested in a ruleset', function() {
+    it('should return a selector for a child rule inside a nested media query', function() {
+      var rule = postcss.rule({selector: '.Component-d'});
+      var media = postcss.atRule({name: 'media'});
+      media.append(rule);
+      componentRoot.append(media);
+
+      assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
+      assert.deepEqual(getSelectors(componentRoot), null);
+    });
+
+    it('should return a selector for a ruleset with declarations and nested media query', function() {
+      componentRoot.append({prop: 'color', value: 'green'});
+      var rule = postcss.rule({selector: '.Component-d'});
+      var media = postcss.atRule({name: 'media'});
+      media.append(rule);
+      componentRoot.append(media);
+
+      assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
+      assert.deepEqual(getSelectors(componentRoot), ['.Component']);
+    });
+  })
+});

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -82,8 +82,7 @@ describe('using SUIT pattern (default)', function() {
       assertSuccess(sUtil('.u-16by9'));
     });
   });
-  
-  
+
   it('accepts chained modifier selectors', function() {
     assertSuccess(s('.Foo--big.Foo--colored'));
     assertSuccess(s('.Foo--big.Foo--colored .Foo-input'));
@@ -93,7 +92,7 @@ describe('using SUIT pattern (default)', function() {
 
   it('accepts chained state selectors', function() {
     assertSuccess(s('.Foo.is-open.is-disabled .Foo-input'));
-    assertSuccess(s('.Foo--big.is-open.is-disabled .Foo-input.is-invalid'));    
+    assertSuccess(s('.Foo--big.is-open.is-disabled .Foo-input.is-invalid'));
     assertSuccess(s('.Foo.is-open.is-disabled .Foo-input.is-invalid'));
   });
 

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -4,6 +4,7 @@ var assertFailure = util.assertFailure;
 var assertSingleFailure = util.assertSingleFailure;
 var selectorTester = util.selectorTester;
 var fixture = util.fixture;
+var assert = require('assert');
 
 describe('using SUIT pattern (default)', function() {
   it('accepts valid component classes', function() {
@@ -101,6 +102,31 @@ describe('using SUIT pattern (default)', function() {
     assertSuccess(s('.Foo[disabled]'));
     assertSuccess(s('.Foo-input[disabled] ~ .Foo-label'));
     assertSuccess(s('.Foo-inner--password .Foo-input[type="password"]'));
+  });
+
+  describe('nesting selectors', function() {
+    it('accepts nested rulesets', function() {
+      assertSuccess(fixture('suit-nesting'));
+    });
+
+    it('rejects an incorrect nested ruleset', function() {
+      assertSingleFailure('/** @define Component */ \n .Component { &--Modifier {} }');
+      assertSingleFailure('/** @define Component */ \n .Component { .component-elem {} }');
+    });
+
+    it('rejects with a single warning when the parent has no declarations', function() {
+      assertSingleFailure('/** @define Component */ \n .component { &--modifier {} }');
+    });
+
+    it('rejects with multiple warnings if the parent has declarations', function() {
+      var result = util.test('/** @define Component */ \n .component { color:red; &--modifier {} }');
+      assert.equal(result.warnings().length, 2);
+    });
+
+    it('correctly reports line number', function() {
+      var result = util.test('/** @define Component */ \n .Component {\n &--modifier {}\n .component-element {} \n}');
+      assert.equal(result.warnings()[0].line, 4);
+    });
   });
 
   describe('strict SUIT syntax', function() {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -5,7 +5,6 @@ var fs = require('fs');
 var postcss = require('postcss');
 
 function getPostcssResult(css, primary, secondary) {
-  // Call then() at the end to make the LazyResult evaluate
   var result = postcss()
     .use(linter(primary, secondary))
     .process(css);


### PR DESCRIPTION
A first stab at #77 

It only supports one level of nesting, which seems ideal for pseudo classes and such.  It does mean things like this will fail though:

``` css
.Component {
  &--modifier {
    .Component-element {}
}
```
Not sure if going any further sends the bem linter into `postcss-nested` territory but if a nested feature lands in the bem linter with caveats it might not be as useful. Open to thoughts on that. 

@dryoma @giuseppeg

Happy to add documentation once this is ready