### PR TITLE
Fix BEM Selector

### DIFF
--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -40,7 +40,7 @@ function bemSelector(block, presetOptions) {
   var ns = (presetOptions && presetOptions.namespace) ? presetOptions.namespace + '-': '';
   var WORD = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
   var element = '(?:__' + WORD + ')?';
-  var modifier = '(?:_' + WORD + '){0,2}';
+  var modifier = '(?:--' + WORD + '){0,2}';
   var attribute = '(?:\\[.+\\])?';
   return new RegExp('^\\.' + ns + block + element + modifier + attribute + '$');
 }


### PR DESCRIPTION
By default, BEM uses a double hyphen to denote a modifier - as opposed to a single underscore.