### PR TITLE
Add implicitComponents and implicitUtilities option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,28 @@ bemLinter({
 ### Defining a component
 
 The plugin will only run if it finds special comments that
-define a named component or a group of utilities.
+define a named component or a group of utilities,
+or the implicit config option is set.
 
-These definitions can be provided in two syntaxes: concise and verbose.
+These comment definitions can be provided in two syntaxes: concise and verbose.
 
 - Concise definition syntax: `/** @define ComponentName */` or `/** @define utilities */`
 - Verbose definition syntax: `/* postcss-bem-linter: define ComponentName */` or `/* postcss-bem-linter: define utilities */`.
 
 Weak mode is turned on by adding `; weak` to a definition,
 e.g. `/** @define ComponentName; weak */` or `/* postcss-bem-linter: define ComponentName; weak */`.
+
+The config options for implicit component definitions takes the following values:
+
+- Enable it for all files: `implicitComponents: true`
+- Enable it for files that match glob pattern: `implicitComponents: 'components/**/*.css'`
+- Enable it for files that match one of multiple glob patterns: `implicitComponents: ['components/**/*.css', 'others/**/*.css']`
+
+The config options for implicit utilities:
+
+- Enable it for files that match glob pattern: `implicitUtilities: 'utils/*.css'`
+- Enable it for files that match one of multiple glob patterns: `implicitUtilities: ['util/*.css', 'bar/**/*.css']`
+
 
 Concise syntax:
 
@@ -308,6 +321,17 @@ Weak mode:
 
 .MyComponent .other {}
 ```
+
+Implicit:
+
+```javascript
+bemLinter({
+  preset: 'bem',
+  implicitComponents: 'components/**/*.css',
+  implicitUtilities: 'utils/*.css'
+});
+```
+
 
 Utilities:
 

--- a/README.md
+++ b/README.md
@@ -254,11 +254,30 @@ bemLinter({
 });
 ```
 
-### Defining a component
+### Defining a component and utilities
 
-The plugin will only run if it finds special comments that
-define a named component or a group of utilities,
-or the implicit config option is set.
+The plugin will only lint the CSS if it knows the context of the CSS: is it a utility or a
+component. To define the context, use the configuration options to define it based on the filename
+(`css/components/*.css`) or use a special comment to define context for the CSS after it.
+When defining a component, the component name is needed.
+
+#### Define components and utilities implicitly based on their filename
+
+When defining a component base on the filename, the name of the file (minus the extension) will be
+used implicitly as the component name for linting.
+The configuration option for implicit components take:
+
+- Enable it for all files: `implicitComponents: true`
+- Enable it for files that match a glob pattern: `implicitComponents: 'components/**/*.css'`
+- Enable it for files that match one of multiple glob patterns: `implicitComponents: ['components/**/*.css', 'others/**/*.css']`
+
+The CSS will implicitly be linted as utilities in files marked as such by their filename.
+The configuration option for implicit utilities take:
+
+- Enable it for files that match a glob pattern: `implicitUtilities: 'utils/*.css'`
+- Enable it for files that match one of multiple glob patterns: `implicitUtilities: ['util/*.css', 'bar/**/*.css']`
+
+#### Define components/utilities with a comment
 
 These comment definitions can be provided in two syntaxes: concise and verbose.
 
@@ -267,18 +286,6 @@ These comment definitions can be provided in two syntaxes: concise and verbose.
 
 Weak mode is turned on by adding `; weak` to a definition,
 e.g. `/** @define ComponentName; weak */` or `/* postcss-bem-linter: define ComponentName; weak */`.
-
-The config options for implicit component definitions takes the following values:
-
-- Enable it for all files: `implicitComponents: true`
-- Enable it for files that match glob pattern: `implicitComponents: 'components/**/*.css'`
-- Enable it for files that match one of multiple glob patterns: `implicitComponents: ['components/**/*.css', 'others/**/*.css']`
-
-The config options for implicit utilities:
-
-- Enable it for files that match glob pattern: `implicitUtilities: 'utils/*.css'`
-- Enable it for files that match one of multiple glob patterns: `implicitUtilities: ['util/*.css', 'bar/**/*.css']`
-
 
 Concise syntax:
 

--- a/index.js
+++ b/index.js
@@ -103,14 +103,11 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
     }
 
     function isImplicitComponent(file) {
-      if (config.implicitComponents === true) {
-        return true;
-
-      } else if (Array.isArray(config.implicitComponents)) {
+      if (Array.isArray(config.implicitComponents)) {
         return checkGlob(file, config.implicitComponents);
       }
 
-      return false;
+      return Boolean(config.implicitComponents);
     }
 
     function isImplicitUtilities(file) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var validateSelectors = require('./lib/validate-selectors');
 var generateConfig = require('./lib/generate-config');
 var toRegexp = require('./lib/to-regexp');
 var path = require('path');
-var minimatch = require('minimatch');
+var minimatchList = require('minimatch-list');
 
 var DEFINE_VALUE = '([-_a-zA-Z0-9]+)\\s*(?:;\\s*(weak))?';
 var DEFINE_DIRECTIVE = new RegExp(
@@ -89,17 +89,9 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
     }
 
     function checkGlob(file, globs) {
-      if (file.indexOf(process.cwd()) === 0) {
-        file = file.substr(process.cwd().length);
-
-        if (file.charAt(0) === path.sep) {
-          file = file.substr(1);
-        }
-      }
-
-      return globs.reduce(function (accumulator, pattern) {
-        return accumulator || minimatch(file, pattern);
-      }, false);
+      // PostCSS turns relative paths into absolute paths
+      file = path.relative(process.cwd(), file);
+      return minimatchList(file, globs);
     }
 
     function isImplicitComponent(file) {

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
     }
 
     function isImplicitComponent(file) {
-      if (Array.isArray(config.implicitComponents)) {
+      if (config.implicitComponents instanceof Array) {
         return checkGlob(file, config.implicitComponents);
       }
 
@@ -103,7 +103,7 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
     }
 
     function isImplicitUtilities(file) {
-      if (Array.isArray(config.implicitUtilities)) {
+      if (config.implicitUtilities instanceof Array) {
         return checkGlob(file, config.implicitUtilities);
       }
 

--- a/index.js
+++ b/index.js
@@ -124,26 +124,28 @@ module.exports = postcss.plugin('postcss-bem-linter', function(primaryOptions, s
     function findRanges(root) {
       var ranges = [];
 
-      var filename = root.source.input.file;
-      if (isImplicitUtilities(filename)) {
-        ranges.push({
-          defined: 'utilities',
-          start: 0,
-          weakMode: false,
-        });
-      } else if (isImplicitComponent(filename)) {
-        var defined = path.basename(filename).split('.')[0]
+      if (root.source && root.source.input && root.source.input.file) {
+        var filename = root.source.input.file;
+        if (isImplicitUtilities(filename)) {
+          ranges.push({
+            defined: 'utilities',
+            start: 0,
+            weakMode: false,
+          });
+        } else if (isImplicitComponent(filename)) {
+          var defined = path.basename(filename).split('.')[0]
 
-        if (defined !== UTILITIES_IDENT && !toRegexp(config.componentNamePattern).test(defined)) {
-          result.warn(
-            'Invalid component name from implicit conversion from filename ' + filename
-          );
+          if (defined !== UTILITIES_IDENT && !toRegexp(config.componentNamePattern).test(defined)) {
+            result.warn(
+              'Invalid component name from implicit conversion from filename ' + filename
+            );
+          }
+          ranges.push({
+            defined: defined,
+            start: 0,
+            weakMode: false,
+          });
         }
-        ranges.push({
-          defined: defined,
-          start: 0,
-          weakMode: false,
-        });
       }
 
       root.walkComments(function(comment) {

--- a/lib/check-implicit.js
+++ b/lib/check-implicit.js
@@ -1,0 +1,46 @@
+var minimatchList = require('minimatch-list');
+var path = require('path');
+
+/**
+ * Check the file matches on of the globs.
+ *
+ * @param {string} filename - The filename to test
+ * @param {string[]} globs - An array of glob strings to test the filename against
+ * @return {boolean}
+ */
+function checkGlob(filename, globs) {
+  // PostCSS turns relative paths into absolute paths
+  filename = path.relative(process.cwd(), filename);
+  return minimatchList(filename, globs);
+}
+
+/**
+ * @param {string[]|boolean} implicitComponentsConfig - The configuration value implicitComponents
+ * @param {string} filename - The filename of the CSS file being checked
+ * @returns {boolean}
+ */
+function isImplicitComponent(implicitComponentsConfig, filename) {
+  if (implicitComponentsConfig instanceof Array) {
+    return checkGlob(filename, implicitComponentsConfig);
+  }
+
+  return Boolean(implicitComponentsConfig);
+}
+
+/**
+ * @param {string[]|boolean} implicitUtilitiesConfig - The configuration value implicitUtilities
+ * @param {string} filename - The filename of the CSS file being checked
+ * @return {boolean}
+ */
+function isImplicitUtilities(implicitUtilitiesConfig, filename) {
+  if (implicitUtilitiesConfig instanceof Array) {
+    return checkGlob(filename, implicitUtilitiesConfig);
+  }
+
+  return false;
+}
+
+module.exports = {
+  isImplicitComponent: isImplicitComponent,
+  isImplicitUtilities: isImplicitUtilities,
+};

--- a/lib/generate-config.js
+++ b/lib/generate-config.js
@@ -46,20 +46,10 @@ module.exports = function(primaryOptions, secondaryOptions) {
     presetOptions = primaryOptions.presetOptions;
   }
 
-  var implicitComponents = secondaryOptions && secondaryOptions.implicitComponents !== undefined ?
-    secondaryOptions.implicitComponents : primaryOptions && primaryOptions.implicitComponents;
-  implicitComponents = implicitComponents === undefined ? false : implicitComponents;
-
-  if (typeof implicitComponents === 'string') {
-    implicitComponents = [implicitComponents];
-  }
-
-  var implicitUtilities = secondaryOptions && secondaryOptions.implicitUtilities !== undefined ?
-    secondaryOptions.implicitUtilities : primaryOptions && primaryOptions.implicitUtilities;
-
-  if (typeof implicitUtilities === 'string') {
-    implicitUtilities = [implicitUtilities];
-  }
+  var implicitComponents =
+    getImplicitDefineValue('implicitComponents', primaryOptions, secondaryOptions);
+  var implicitUtilities =
+    getImplicitDefineValue('implicitUtilities', primaryOptions, secondaryOptions);
 
   return {
     patterns: patterns,
@@ -68,4 +58,20 @@ module.exports = function(primaryOptions, secondaryOptions) {
     implicitComponents: implicitComponents,
     implicitUtilities: implicitUtilities,
   };
+}
+
+function getImplicitDefineValue(key, primaryOptions, secondaryOptions) {
+  var implicitValue = false;
+
+  if (secondaryOptions && secondaryOptions[key] !== undefined) {
+    implicitValue = secondaryOptions[key];
+  } else if (primaryOptions && primaryOptions[key]) {
+    implicitValue = primaryOptions[key]
+  }
+
+  if (typeof implicitValue === 'string') {
+    implicitValue = [implicitValue];
+  }
+
+  return implicitValue;
 }

--- a/lib/generate-config.js
+++ b/lib/generate-config.js
@@ -46,9 +46,26 @@ module.exports = function(primaryOptions, secondaryOptions) {
     presetOptions = primaryOptions.presetOptions;
   }
 
+  var implicitComponents = secondaryOptions && secondaryOptions.implicitComponents !== undefined ?
+    secondaryOptions.implicitComponents : primaryOptions && primaryOptions.implicitComponents;
+  implicitComponents = implicitComponents === undefined ? false : implicitComponents;
+
+  if (typeof implicitComponents === 'string') {
+    implicitComponents = [implicitComponents];
+  }
+
+  var implicitUtilities = secondaryOptions && secondaryOptions.implicitUtilities !== undefined ?
+    secondaryOptions.implicitUtilities : primaryOptions && primaryOptions.implicitUtilities;
+
+  if (typeof implicitUtilities === 'string') {
+    implicitUtilities = [implicitUtilities];
+  }
+
   return {
     patterns: patterns,
     presetOptions: presetOptions,
     componentNamePattern: patterns.componentName || /^[-_a-zA-Z0-9]+$/,
-  }
+    implicitComponents: implicitComponents,
+    implicitUtilities: implicitUtilities,
+  };
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "dependencies": {
-    "minimatch": "^3.0.3",
+    "minimatch-list": "0.0.1",
     "postcss": "^5.0.0",
     "postcss-resolve-nested-selector": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "dependencies": {
+    "minimatch": "^3.0.3",
     "postcss": "^5.0.0",
     "postcss-resolve-nested-selector": "^0.1.1"
   },

--- a/test/definition.js
+++ b/test/definition.js
@@ -25,3 +25,41 @@ describe('`@define` notation', function() {
     });
   });
 });
+
+describe('Implicit @define', function() {
+  describe('based on filename', function() {
+    var filename = process.cwd() + '/css/c/implicit-component.css';
+    var css = '.implicit-component-broken {}';
+
+    it('must complain when true', function() {
+      util.assertSingleFailure(css, {implicitComponents: true, preset: 'bem'}, null, filename);
+    });
+
+    it('must complain when string', function() {
+      util.assertSingleFailure(css, {implicitComponents: 'css/**/*.css', preset: 'bem'}, null, filename);
+    });
+
+    it('must complain when array', function() {
+      util.assertSingleFailure(css, {implicitComponents: ['css/c/*.css'], preset: 'bem'}, null, filename);
+    });
+
+    it('must complain about component name', function() {
+      util.assertSingleFailure(
+        css,
+        {
+          implicitComponents: true,
+          componentName: /[A-Z]+/,
+          componentSelectors: function() { return /.*/; },
+        },
+        null,
+        filename
+      );
+    });
+  });
+
+  describe('utilities', function() {
+    it('must complain', function() {
+      util.assertSingleFailure('.foo-bar {}', {implicitUtilities: ['utils/*.css'], preset: 'suit'}, null, 'utils/foo-bar.css');
+    });
+  });
+});

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -4,10 +4,10 @@ var linter = require('..');
 var fs = require('fs');
 var postcss = require('postcss');
 
-function getPostcssResult(css, primary, secondary) {
+function getPostcssResult(css, primary, secondary, filename) {
   var result = postcss()
     .use(linter(primary, secondary))
-    .process(css);
+    .process(css, {from: filename});
   return result;
 }
 
@@ -15,18 +15,18 @@ function fixture(name) {
   return fs.readFileSync(path.join(__dirname, 'fixtures', name + '.css'), 'utf8').trim();
 }
 
-function assertSuccess(css, primary, secondary) {
-  var result = getPostcssResult(css, primary, secondary);
+function assertSuccess(css, primary, secondary, filename) {
+  var result = getPostcssResult(css, primary, secondary, filename);
   assert.equal(result.warnings().length, 0);
 }
 
-function assertSingleFailure(css, primary, secondary) {
-  var result = getPostcssResult(css, primary, secondary);
+function assertSingleFailure(css, primary, secondary, filename) {
+  var result = getPostcssResult(css, primary, secondary, filename);
   assert.equal(result.warnings().length, 1);
 }
 
-function assertFailure(css, primary, secondary) {
-  var result = getPostcssResult(css, primary, secondary);
+function assertFailure(css, primary, secondary, filename) {
+  var result = getPostcssResult(css, primary, secondary, filename);
   assert.ok(result.warnings().length > 0);
 }
 


### PR DESCRIPTION
This adds the options of `implicitComponents` and `implicitUtilities` as described in [issue 88](https://github.com/postcss/postcss-bem-linter/issues/88).

The values for the options:

`implicitComponents`

- `true` enables it for all files
- glob string to test the filename
- array of glob strings to test the filename

`implicitUtilities`

Matches for  `implicitUtilities` takes precedent over matches for `implicitComponents`.

- glob string to test the filename
- array of glob strings to test the filename