### PR TITLE
Check existence of node.nodes in hasNoDeclarations

### DIFF
--- a/lib/get-selectors.js
+++ b/lib/get-selectors.js
@@ -9,7 +9,7 @@ function isNestedRule(node) {
 }
 
 function hasNoDeclarations(node) {
-  return node.nodes.length && node.every(function(child) {
+  return node.nodes && node.nodes.length && node.every(function(child) {
     return child.type !== 'decl';
   });
 }

--- a/test/nesting.js
+++ b/test/nesting.js
@@ -15,6 +15,14 @@ describe('getSelectors', function() {
     assert.deepEqual(getSelectors(componentRoot), ['.Component']);
   });
 
+  it('should check for the existence of child nodes', function() {
+    var rule = postcss.rule({selector: '.Component-d'});
+    rule.nodes = undefined;
+    componentRoot.append(rule);
+
+    assert.deepEqual(getSelectors(rule), ['.Component .Component-d']);
+  });
+
   describe('ruleset declarations with nested rulesets', function() {
     it('should ignore a ruleset that has no declarations', function() {
       componentRoot.append({selector: '.Component-d'});


### PR DESCRIPTION
While trying to use the [stylelint-selector-bem-pattern](https://github.com/davidtheclark/stylelint-selector-bem-pattern ) plugin (which uses `postcss-bem-linter` [under the hood](https://github.com/davidtheclark/stylelint-selector-bem-pattern/blob/master/package.json#L33)) in tandem with [stylelint](https://github.com/stylelint/stylelint), using less syntax supplied by [postcss-less](https://github.com/shellscape/postcss-less), I noticed that the linter would error upon trying to parse mixins (as reported in #104), i.e.:

Contrived, breaking code:

```less
/** @define MyComponent */
.mixin {
    background: black;
}

.MyComponent {
    .mixin;
    &:extend(.mixin);
}
```

yields:

```
TypeError: Cannot read property 'length' of undefined
    at hasNoDeclarations (node_modules\postcss-bem-linter\lib\get-selectors.js:12:20)
    at getSelectors (node_modules\postcss-bem-linter\lib\get-selectors.js:39:7)
    at module.exports (node_modules\postcss-bem-linter\lib\validate-selectors.js:27:19)
    at checkRule (node_modules\postcss-bem-linter\index.js:80:7)
    at node_modules\postcss-bem-linter\index.js:47:9
    at Array.forEach (native)
    at node_modules\postcss-bem-linter\index.js:44:14
    at node_modules\postcss\lib\container.js:241:28
    at node_modules\postcss\lib\container.js:148:26
    at Root.each (node_modules\postcss\lib\container.js:114:22)
```

After existence check, yields proper output:

```
input.less
3:1     ‼  Invalid component selector ".mixin" (plugin/selector-bem-pattern) [stylelint]
8:3     ‼  Invalid component selector ".MyComponent .mixin" (plugin/selector-bem-pattern) [stylelint]
```

I know that this project is not less (or other pre-processor)-specific, but a seemingly innocuous change of checking for the existence of `node.nodes` before accessing `.length` resolves this issue. This fix would also resolve #104.

As far as the history of this issue: it looks like it can be sort of traced back to [postcss-less#33](https://github.com/shellscape/postcss-less/issues/33), where a decision was made to mimic the behavior of `postcss-scss`, which sets `node.nodes` to `undefined` when there are no children of a given rule. I can't speak to the how or why of that, but it's arguable about whether or not a discussion/fix belongs in a different project as well.