### PR TITLE
Allow both /** and /* for module definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const checkImplicit = require('./lib/check-implicit');
 
 const DEFINE_VALUE = '([-_a-zA-Z0-9]+)\\s*(?:;\\s*(weak))?';
 const DEFINE_DIRECTIVE = new RegExp(
-  `(?:\\*\\s*@define ${DEFINE_VALUE})|(?:\\s*postcss-bem-linter: define ${DEFINE_VALUE})\\s*`
+  `(?:\\*?\\s*@define ${DEFINE_VALUE})|(?:\\s*postcss-bem-linter: define ${DEFINE_VALUE})\\s*`
 );
 const END_DIRECTIVE = new RegExp(
   '(?:\\*\\s*@end\\s*)|' +

--- a/test/definition.js
+++ b/test/definition.js
@@ -21,6 +21,13 @@ describe('`@define` notation', () => {
     });
   });
 
+  describe('CSS with a rule violating defintion', () => {
+    it('should complain', () => {
+      util.assertFailure('/** @define Foo */ .Bar { color: pink; }');
+      util.assertFailure('/* @define Foo */ .Bar { color: pink; }');
+    });
+  });
+
   describe('CSS with a definition violating the `componentName` pattern', () => {
     it('must complain', () => {
       util.assertSingleFailure('/** @define my-_-__Component */ .my-_-__Component { color: pink; }');


### PR DESCRIPTION
Thanks for this excellent plugin!

We've been using this to enforce our usage of suit-style css, but found that for some of our module definitions, the linter was silently failing when the module definitions were _close_ but not quite right.

In this case, we found that the `/* @define Foo */` would look correct, but not trigger the linter.

This seemed to be because the comment text provided by the `walkComment` callback includes everything after the initial `/*`, so the `DEFINE_DIRECTIVE` was matching against `* @define Foo`, and just `@define Foo` would fail the match.

This PR adds an optional flag to the regex and adds some tests to ensure that a correctly defined definition recognizes a bad rule.

I noticed that there were some comments and PRs related (like [this one](https://github.com/postcss/postcss-bem-linter/issues/116)) but I'm not sure if this is an intended behavior to only have the `/**` style vs also allowing `/*`. Interested to hear your thoughts!
