### PR TITLE
make getComponentRootRule reach the top level **rule** instead of **root**, fixes issue 138

### DIFF
--- a/lib/get-selectors.js
+++ b/lib/get-selectors.js
@@ -22,7 +22,7 @@ function hasOnlyExtends(node) {
 }
 
 function getComponentRootRule(node) {
-  while (node.root() !== node) {
+  while (node.root() !== node.parent) {
     node = node.parent;
   }
   return node;


### PR DESCRIPTION
make getComponentRootRule reach the top level **rule** instead of **root**, fixes issue #138