### PR TITLE
Update unWrapSelectors function to prevent wrong warnings.

### DIFF
--- a/lib/get-selectors.js
+++ b/lib/get-selectors.js
@@ -21,23 +21,10 @@ function hasOnlyExtends(node) {
   );
 }
 
-function getComponentRootRule(node) {
-  while (node.root() !== node.parent) {
-    node = node.parent;
-  }
-  return node;
-}
-
-function unWrapSelectors(parent, rule) {
+function unWrapSelectors(rule) {
   let selectors = [];
-  parent.walkRules(node => {
-    // Only unwrap as far as the current rule being linted
-    if (node.selector !== rule.selector) {
-      return;
-    }
-    node.selectors.forEach(selector => {
-      selectors = selectors.concat(resolveNestedSelector(selector, node));
-    });
+  rule.selectors.forEach(selector => {
+    selectors = selectors.concat(resolveNestedSelector(selector, rule));
   });
   return selectors;
 }
@@ -50,9 +37,7 @@ function getSelectors(rule) {
   }
 
   if (isNestedRule(rule)) {
-    const componentRootRule = getComponentRootRule(rule);
-    const nestedSelectors = unWrapSelectors(componentRootRule, rule);
-    return nestedSelectors;
+    return unWrapSelectors(rule);
   }
 
   return rule.selectors;

--- a/test/nesting.js
+++ b/test/nesting.js
@@ -67,6 +67,20 @@ describe('getSelectors', () => {
       assert.deepEqual(getSelectors(rule), ['.Component.is-active']);
     });
 
+    it('should unwrap selector only once', () => {
+      const firstRule = postcss.rule({selector: '.Component-d'});
+      const secondRule = postcss.rule({selector: '&.is-active'});
+      const firstHover = postcss.rule({selector: '&:hover'});
+      const secondHover = postcss.rule({selector: '&:hover'});
+      firstRule.append(firstHover);
+      secondRule.append(secondHover);
+      componentRoot.append(firstRule);
+      componentRoot.append(secondRule);
+      assert.deepEqual(getSelectors(firstHover), [
+        '.Component .Component-d:hover',
+      ]);
+    });
+
     it('should unwrap multiple levels of nested rulesets and skip rules with no declarations', () => {
       const descendant = postcss.rule({selector: '.Component-d'});
       const hover = postcss.rule({selector: '&:hover'});


### PR DESCRIPTION
We used this scss for tests:
```
.dropdown_type_one {
  @media (min-width: $tablet-landscape) { 
    &.menu__item_selected {
      > .dropdown__handle {
        &::after {
          background-image: none;
        }
      }
    }
  }
  &.menu__item_some-modifier {
    > .dropdown__handle {
      background-image: none;
      &::after {
        @media (min-width: $tablet-landscape) {
          display: none;
        }
      }
    }
  }
}

```

And got the following output:
```
5:9  ✖  Invalid component selector ".dropdown_type_one.menu__item_selected > .dropdown__handle::after"        plugin/selector-bem-pattern
5:9  ✖  Invalid component selector ".dropdown_type_one.menu__item_some-modifier > .dropdown__handle::after"   plugin/selector-bem-pattern
13:5  ✖  Invalid component selector ".dropdown_type_one.menu__item_selected > .dropdown__handle"               plugin/selector-bem-pattern
13:5  ✖  Invalid component selector ".dropdown_type_one.menu__item_some-modifier > .dropdown__handle"          plugin/selector-bem-pattern
```
Each time when unWrapSelectors works for any rule with '::after' selector it will get all the nodes with such a selector and unwrap them. In our example it will produce duplication of warnings. Here is our solution to fix this.
