### PR TITLE
Added "include" as allowed at-rule in hasOnlyAllowedAtRules function

### DIFF
--- a/lib/get-selectors.js
+++ b/lib/get-selectors.js
@@ -22,7 +22,7 @@ function hasOnlyAllowedAtRules(node) {
     node.each(child => {
       if (
         child.type === 'atrule' &&
-        (child.name === 'extend' || child.name === 'media')
+        (child.name === 'extend' || child.name === 'media' || child.name === 'include')
       ) {
         containsAllowed = true;
       } else if (child.type !== 'comment') {


### PR DESCRIPTION
This extends the fix in #140, but fixes linting for selectors that only includes at-rules with `@include` within it for better Sass/SCSS support.

The error:

```SCSS
/** @define foo */

.foo {}

// This selector is ignored even though it's an error, as it only contains
// an @include at-rule
.bar {
    @include col-init();
}

// This is also ignored even though it contains the allow @extend at-rule as it
// also includes the @include at-rule and no other styling properties
.test {
    @include col-init();

    @extend %test-extend;
}
```