### PR TITLE
fix typo for modifier inside bemSelector fn preset

### DIFF
--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -45,7 +45,7 @@ function bemSelector(block, presetOptions) {
       : '';
   const WORD = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
   const element = `(?:__${WORD})?`;
-  const modifier = `(?:(?:_|--)${WORD}){0,2}`;
+  const modifier = `(?:_|--)${WORD}){0,2}`;
   const attribute = '(?:\\[.+\\])?';
   return new RegExp(`^\\.${ns}${block}${element}${modifier}${attribute}$`);
 }


### PR DESCRIPTION
I was trying to use this for the first time and I wanted to use the BEM preset but the (--) modifiers were not working, I was getting an error as it my class modifier with (--) was not allowed. Went for the source code and found the function where the preset is created, and I found a typo.

Now the modifier works well. Let me know if you have any comments, this is my very first contribution!