### PR TITLE
Fix `implicitComponents` with a string `componentName` pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Please note that this project is released with a Contributor Code of Conduct. By
 
 ### Development
 
-Install the dependencies. Requires [Yarn](https://yarnpkg.com/)
+Install dependencies. Requires [Yarn 1.x (Classic)](https://classic.yarnpkg.com/)
 
 ```
 yarn

--- a/lib/generate-config.js
+++ b/lib/generate-config.js
@@ -7,11 +7,11 @@ const presetPatterns = require('./preset-patterns');
  * the validators can use.
  *
  * @param {Object|String} [primaryOptions = 'suit']
- * @param {RegExp} [primaryOptions.componentName]
- * @param {RegExp} [primaryOptions.utilitySelectors]
+ * @param {RegExp|String} [primaryOptions.componentName]
+ * @param {RegExp|String} [primaryOptions.utilitySelectors]
  * @param {Object|Function} [primaryOptions.componentSelectors]
- * @param {RegExp} [primaryOptions.ignoreSelectors]
- * @param {RegExp} [primaryOptions.ignoreCustomProperties]
+ * @param {RegExp|String} [primaryOptions.ignoreSelectors]
+ * @param {RegExp|String} [primaryOptions.ignoreCustomProperties]
  * @param {String} [primaryOptions.preset] - The same as passing a string for `primaryOptions`
  * @param {Object} [primaryOptions.presetOptions] - Options that are can be used by
  *   a pattern (e.g. `namespace`)

--- a/lib/get-component-name-from-filename.js
+++ b/lib/get-component-name-from-filename.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const toRegexp = require('./to-regexp');
+
 /**
  * @param {String} filename
  * @param {Object} config
@@ -8,11 +10,11 @@
 module.exports = (filename, config) => {
   const {componentNamePattern} = config;
 
-  if (componentNamePattern.test(filename)) return filename;
+  if (toRegexp(componentNamePattern).test(filename)) return filename;
 
   for (let i = 0; i < filename.length; i++) {
     const part = filename.slice(0, -i);
-    if (componentNamePattern.test(part)) return part;
+    if (toRegexp(componentNamePattern).test(part)) return part;
   }
 
   return filename;

--- a/lib/get-component-name-from-filename.js
+++ b/lib/get-component-name-from-filename.js
@@ -5,7 +5,7 @@ const toRegexp = require('./to-regexp');
 /**
  * @param {String} filename
  * @param {Object} config
- * @param {String} config.componentNamePattern
+ * @param {RegExp|String} config.componentNamePattern
  */
 module.exports = (filename, config) => {
   const {componentNamePattern} = config;

--- a/test/definition.js
+++ b/test/definition.js
@@ -41,7 +41,9 @@ describe('Implicit @define', () => {
   describe('based on filename', () => {
     const filename = `${process.cwd()}/css/c/implicit-component.css`;
     const filenameWithUnderscore = `${process.cwd()}/css/c/_implicit-component.scss`;
+    const validFileName = `${process.cwd()}/css/c/IMPLICITCOMPONENT.css`;
     const css = '.implicit-component-broken {}';
+    const validCss = '.IMPLICITCOMPONENT {}';
 
     it('must complain when true', () => {
       util.assertSingleFailure(
@@ -133,6 +135,36 @@ describe('Implicit @define', () => {
         },
         null,
         filenameWithUnderscore
+      );
+    });
+
+    it('must complain about component name with componentName pattern as a string', () => {
+      util.assertSingleFailure(
+        css,
+        {
+          implicitComponents: true,
+          componentName: '[A-Z]+',
+          componentSelectors() {
+            return /.*/;
+          },
+        },
+        null,
+        filename
+      );
+    });
+
+    it('must pass valid component name with componentName pattern as a string', () => {
+      util.assertSuccess(
+        validCss,
+        {
+          implicitComponents: true,
+          componentName: '[A-Z]+',
+          componentSelectors() {
+            return /.*/;
+          },
+        },
+        null,
+        validFileName
       );
     });
   });


### PR DESCRIPTION
Fixes #174.

The first commit (a31c272e22fca91b0824a072d22a43ed37bcf7b6) is the failing test on its own.

Commit 9c83e0fdbd4def0a7056d638df80029855a3c256 fixes the issue by using `toRegexp`, which seemed to be the common pattern for similar cases where a string or RegExp was expected to be used as regex.

Some additional changes currently not included but worth considering:
- Changing the docstring types to reflect the modules accepting either string or RegExp, applies to at least `lib/get-component-name-from-filename.js` and `lib/generate-config.js`
- When setting up I noticed the project is still using Yarn Classic (1.x) so updating the readme to mention it would be useful, as Yarn's instructions tell you to install modern Yarn (3.x).

@simonsmith let me know what you think!